### PR TITLE
Replace discount calculator with basic arithmetic app

### DIFF
--- a/app/src/main/java/com/example/myapplication1/MainActivity.java
+++ b/app/src/main/java/com/example/myapplication1/MainActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
 
 import androidx.activity.EdgeToEdge;
 import androidx.appcompat.app.AppCompatActivity;
@@ -13,57 +14,9 @@ import androidx.core.view.WindowInsetsCompat;
 
 public class MainActivity extends AppCompatActivity {
 
-    private Button bdesc;
-    private EditText precio, descuento, resultado;
-
-
-    private void calculadora_descuento() {
-
-        double p = Double.parseDouble(precio.getText().toString());
-        double d = Double.parseDouble(descuento.getText().toString());
-
-
-        String mensaje = "";
-
-        if (d < 0) {
-            mensaje = "Descuento inválido";
-        }
-        else if (d < 10) {
-            mensaje = "Descuento bajo";
-        }
-        else if (d < 20) {
-            mensaje = "Descuento medio";
-        }
-        else if (d < 30) {
-            mensaje = "Descuento alto";
-        }
-        else if (d <= 100) {
-            mensaje = "Súper descuento";
-        }
-        else {
-            mensaje = "Descuento inválido";
-        }
-
-
-        double precioFinal = calc(p, d);
-
-        // mostrar solamente dos decimales
-        String formato = String.format("%.2f", precioFinal);
-
-
-        resultado.setText("Precio final = $" + formato + " → " + mensaje);
-    }
-
-    // FUNCION (retorna un valor)
-    private double calc(double precioBase, double descuentoPorc) {
-        // Si el descuento no es válido, retorno el mismo precio
-        if (descuentoPorc < 0 || descuentoPorc > 100) {
-            return precioBase;
-        }
-        double rebaja = precioBase * (descuentoPorc / 100.0);
-        return precioBase - rebaja;
-    }
-
+    private EditText num1, num2;
+    private TextView result;
+    private Button btnSum, btnRes, btnMul, btnDiv;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -71,26 +24,53 @@ public class MainActivity extends AppCompatActivity {
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_main);
 
+        num1 = findViewById(R.id.num1);
+        num2 = findViewById(R.id.num2);
+        result = findViewById(R.id.result);
+        btnSum = findViewById(R.id.btnSum);
+        btnRes = findViewById(R.id.btnRes);
+        btnMul = findViewById(R.id.btnMul);
+        btnDiv = findViewById(R.id.btnDiv);
 
-        precio   = findViewById(R.id.precio
-        );
-        descuento = findViewById(R.id.desc);
-        resultado  = findViewById(R.id.result);
-        bdesc    = findViewById(R.id.button);
+        View.OnClickListener listener = v -> {
+            double n1 = getValue(num1);
+            double n2 = getValue(num2);
+            double r;
 
-
-        bdesc.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                calculadora_descuento();
+            if (v.getId() == R.id.btnSum) {
+                r = n1 + n2;
+            } else if (v.getId() == R.id.btnRes) {
+                r = n1 - n2;
+            } else if (v.getId() == R.id.btnMul) {
+                r = n1 * n2;
+            } else { // btnDiv
+                if (n2 == 0) {
+                    result.setText("Error: división por cero");
+                    return;
+                }
+                r = n1 / n2;
             }
-        });
 
+            result.setText(String.format("%.2f", r));
+        };
+
+        btnSum.setOnClickListener(listener);
+        btnRes.setOnClickListener(listener);
+        btnMul.setOnClickListener(listener);
+        btnDiv.setOnClickListener(listener);
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
             return insets;
         });
+    }
+
+    private double getValue(EditText field) {
+        String text = field.getText().toString();
+        if (text.isEmpty()) {
+            return 0;
+        }
+        return Double.parseDouble(text);
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,119 +8,107 @@
     android:background="@color/lilac"
     tools:context=".MainActivity">
 
-
     <TextView
-        android:id="@+id/textView"
-        android:layout_width="88dp"
-        android:layout_height="49dp"
-        android:background="@drawable/border"
-        android:gravity="center"
-        android:text="Descuento %"
-        android:textAlignment="center"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.065"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.244" />
-
-    <TextView
-        android:id="@+id/textView2"
+        android:id="@+id/title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="Calculadora"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="32dp"/>
+
+    <EditText
+        android:id="@+id/num1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginTop="32dp"
+        android:background="@drawable/border"
+        android:ems="10"
+        android:gravity="center"
+        android:hint="Número 1"
+        android:inputType="numberDecimal"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <EditText
+        android:id="@+id/num2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/border"
+        android:ems="10"
+        android:gravity="center"
+        android:hint="Número 2"
+        android:inputType="numberDecimal"
+        app:layout_constraintTop_toBottomOf="@id/num1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <LinearLayout
+        android:id="@+id/buttonContainer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="32dp"
+        app:layout_constraintTop_toBottomOf="@id/num2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <Button
+            android:id="@+id/btnSum"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:text="+"
+            android:background="@drawable/border"/>
+
+        <Button
+            android:id="@+id/btnRes"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginStart="8dp"
+            android:text="-"
+            android:background="@drawable/border"/>
+
+        <Button
+            android:id="@+id/btnMul"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginStart="8dp"
+            android:text="×"
+            android:background="@drawable/border"/>
+
+        <Button
+            android:id="@+id/btnDiv"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginStart="8dp"
+            android:text="÷"
+            android:background="@drawable/border"/>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/result"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginTop="32dp"
         android:background="@drawable/border"
         android:gravity="center"
         android:padding="16dp"
-        android:text="Precio $"
+        android:text="Resultado"
         android:textAlignment="center"
-        android:textColor="#000000"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.064"
+        android:textSize="18sp"
+        app:layout_constraintTop_toBottomOf="@id/buttonContainer"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.133" />
-
-    <Button
-        android:id="@+id/button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Calcular"
-        android:background="@drawable/border"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.498"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.8" />
-
-    <EditText
-        android:id="@+id/precio"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:hint="Precio"
-        android:inputType="text"
-        android:gravity="center"
-    android:textAlignment="center"
-    android:background="@drawable/border"
-    android:ems="10"
-    android:textColor="#000000"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintHorizontal_bias="0.771"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    app:layout_constraintVertical_bias="0.144" />
-
-    <EditText
-        android:id="@+id/desc"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:hint="Descuento"
-        android:inputType="number|numberDecimal"
-        android:gravity="center"
-    android:textAlignment="center"
-    android:background="@drawable/border"
-    android:ems="10"
-    android:textColor="#000000"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintHorizontal_bias="0.771"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    app:layout_constraintVertical_bias="0.249" />
-
-
-    <EditText
-        android:id="@+id/result"
-        android:layout_width="363dp"
-        android:layout_height="93dp"
-        android:hint="Resultado"
-        android:inputType="text"
-        android:ems="10"
-        android:background="@drawable/border"
-    android:gravity="center"
-    android:textAlignment="center"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintHorizontal_bias="0.412"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    app:layout_constraintVertical_bias="0.486" />
-
-    <TextView
-        android:id="@+id/textView3"
-        android:layout_width="340dp"
-        android:layout_height="32dp"
-        android:text="DESCUENTO DE PRECIOS"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.492"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.022" />
-
+        app:layout_constraintEnd_toEndOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">My Application1</string>
+    <string name="app_name">Calculadora</string>
 </resources>


### PR DESCRIPTION
## Summary
- Replace discount-based logic with simple arithmetic operations (add, subtract, multiply, divide)
- Redesign layout for friendlier calculator interface
- Update app name to "Calculadora"

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae358de7fc832582c6e53880fca4eb