### PR TITLE
feat: add clear button and enlarge text

### DIFF
--- a/app/src/main/java/com/example/myapplication1/MainActivity.java
+++ b/app/src/main/java/com/example/myapplication1/MainActivity.java
@@ -16,7 +16,7 @@ public class MainActivity extends AppCompatActivity {
 
     private EditText num1, num2;
     private TextView result;
-    private Button btnSum, btnRes, btnMul, btnDiv;
+    private Button btnSum, btnRes, btnMul, btnDiv, btnClear;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -31,6 +31,7 @@ public class MainActivity extends AppCompatActivity {
         btnRes = findViewById(R.id.btnRes);
         btnMul = findViewById(R.id.btnMul);
         btnDiv = findViewById(R.id.btnDiv);
+        btnClear = findViewById(R.id.btnClear);
 
         View.OnClickListener listener = v -> {
             double n1 = getValue(num1);
@@ -58,6 +59,11 @@ public class MainActivity extends AppCompatActivity {
         btnRes.setOnClickListener(listener);
         btnMul.setOnClickListener(listener);
         btnDiv.setOnClickListener(listener);
+        btnClear.setOnClickListener(v -> {
+            num1.setText("");
+            num2.setText("");
+            result.setText("");
+        });
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -32,6 +32,7 @@
         android:gravity="center"
         android:hint="Número 1"
         android:inputType="numberDecimal"
+        android:textSize="24sp"
         app:layout_constraintTop_toBottomOf="@id/title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
@@ -48,6 +49,7 @@
         android:gravity="center"
         android:hint="Número 2"
         android:inputType="numberDecimal"
+        android:textSize="24sp"
         app:layout_constraintTop_toBottomOf="@id/num1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
@@ -67,7 +69,8 @@
             android:layout_width="64dp"
             android:layout_height="64dp"
             android:text="+"
-            android:background="@drawable/border"/>
+            android:background="@drawable/border"
+            android:textSize="24sp"/>
 
         <Button
             android:id="@+id/btnRes"
@@ -75,7 +78,8 @@
             android:layout_height="64dp"
             android:layout_marginStart="8dp"
             android:text="-"
-            android:background="@drawable/border"/>
+            android:background="@drawable/border"
+            android:textSize="24sp"/>
 
         <Button
             android:id="@+id/btnMul"
@@ -83,7 +87,8 @@
             android:layout_height="64dp"
             android:layout_marginStart="8dp"
             android:text="×"
-            android:background="@drawable/border"/>
+            android:background="@drawable/border"
+            android:textSize="24sp"/>
 
         <Button
             android:id="@+id/btnDiv"
@@ -91,7 +96,17 @@
             android:layout_height="64dp"
             android:layout_marginStart="8dp"
             android:text="÷"
-            android:background="@drawable/border"/>
+            android:background="@drawable/border"
+            android:textSize="24sp"/>
+
+        <Button
+            android:id="@+id/btnClear"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginStart="8dp"
+            android:text="C"
+            android:background="@drawable/border"
+            android:textSize="24sp"/>
     </LinearLayout>
 
     <TextView
@@ -106,7 +121,7 @@
         android:padding="16dp"
         android:text="Resultado"
         android:textAlignment="center"
-        android:textSize="18sp"
+        android:textSize="24sp"
         app:layout_constraintTop_toBottomOf="@id/buttonContainer"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>


### PR DESCRIPTION
## Summary
- Add dedicated clear button to reset both inputs and the result
- Increase text size for number fields, operation buttons and result label for better visibility

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68ae4fe5d3f88325926016474ca4bb39