### PR TITLE
Add MainActivity and fix orientation for rabbit puzzle

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:theme="@style/Theme.Conejos">
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:screenOrientation="landscape">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/conejossaltarines/MainActivity.kt
+++ b/app/src/main/java/com/example/conejossaltarines/MainActivity.kt
@@ -1,0 +1,19 @@
+package com.example.conejossaltarines
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Main entry point of the application. It simply inflates the layout that
+ * represents the puzzle board of the rabbits.
+ *
+ * The activity is declared in the manifest with a fixed landscape orientation
+ * so that the board is always shown horizontally as required by the app's
+ * design.
+ */
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}


### PR DESCRIPTION
## Summary
- add missing MainActivity to launch rabbit puzzle layout
- force landscape orientation so board displays horizontally

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e440c50832591f4d2ef9ad09f67